### PR TITLE
Some improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,39 @@ Dragonfly's mailing list/discussion group is available at
 [Google Groups](https://groups.google.com/forum/#!forum/dragonflyspeech).
 
 
+Google Cloud Speech API
+----------------------------------------------------------------------------
+The Google Cloud Speech API dragonfly engine can be used as an alternative
+to the DNS and WSR engines. It should work on Windows, macOS and Linux
+through [Aenea](https://github.com/dictation-toolbox/aenea).
+
+In order to use the engine, you will need to [install the Google Cloud SDK](https://cloud.google.com/sdk/)
+and then [obtain application credentials](https://googlecloudplatform.github.io/google-cloud-python/latest/core/auth.html)
+using:
+``` Shell
+gcloud auth application-default login
+```
+
+To install *dragonfly* and the dependencies for the engine use the following:
+``` Shell
+python setup.py install
+```
+
+You may need to
+[install the Python headers](https://stackoverflow.com/questions/21530577/fatal-error-python-h-no-such-file-or-directory)
+if `Python.h` cannot be found.
+
+You'll then need to copy the *dragonfly_cloud_loader.py* script from
+*dragonfly/examples* into the folder containing your grammar modules and run
+it using:
+``` Shell
+python dragonfly_cloud_loader.py
+```
+
+This is the equivalent to the *MacroSystem/Core* directory that NatLink uses
+to load grammar modules.
+
+
 Features
 ----------------------------------------------------------------------------
 

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -18,6 +18,8 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
+import sys
+
 #---------------------------------------------------------------------------
 from .config            import Config, Section, Item
 from .error             import DragonflyError
@@ -27,7 +29,7 @@ from .engines           import get_engine, EngineError, MimicFailure
 
 #---------------------------------------------------------------------------
 from .grammar.grammar_base       import Grammar
-# from .grammar.grammar_connection import ConnectionGrammar
+from .grammar.grammar_connection import ConnectionGrammar
 from .grammar.rule_base          import Rule
 from .grammar.rule_compound      import CompoundRule
 from .grammar.rule_mapping       import MappingRule
@@ -37,29 +39,30 @@ from .grammar.elements  import (ElementBase, Sequence, Alternative,
                                 RuleRef, RuleWrap, Empty, Compound, Choice)
 from .grammar.context   import Context, AppContext
 from .grammar.list      import ListBase, List, DictList
-# from .grammar.recobs    import (RecognitionObserver, RecognitionHistory,
-#                                 PlaybackHistory)
+from .grammar.recobs    import (RecognitionObserver, RecognitionHistory,
+                                PlaybackHistory)
 
 #from .grammar.number    import (Integer, IntegerRef, Digits, DigitsRef,
 #                                Number, NumberRef)
 
 #---------------------------------------------------------------------------
-from .actions           import (ActionBase, DynStrActionBase, Function, Mimic, Pause, Repeat)
-# from .actions           import (ActionBase, DynStrActionBase, ActionError,
-#                                 Repeat, Key, Text, Mouse, Paste, Pause,
-#                                 Mimic, Playback, WaitWindow, FocusWindow,
-#                                 Function, StartApp, BringApp, PlaySound)
-# from .actions.keyboard  import Typeable, Keyboard
-# from .actions.typeables import typeables
-# from .actions.sendinput import (KeyboardInput, MouseInput, HardwareInput,
-#                                 make_input_array, send_input_array)
+
+from .actions           import (ActionBase, DynStrActionBase, ActionError,
+                                 Repeat, Key, Text, Mouse, Paste, Pause,
+                                 Mimic, Playback, WaitWindow, FocusWindow,
+                                 Function, StartApp, BringApp, PlaySound)
 
 #---------------------------------------------------------------------------
-# from .windows.point     import Point
-# from .windows.rectangle import Rectangle, unit
-# from .windows.window    import Window
-# from .windows.monitor   import Monitor, monitors
-# from .windows.clipboard import Clipboard
+
+# OS agnostic imports
+from .windows.rectangle import Rectangle, unit
+from .windows.point     import Point
+
+# Windows-specific
+from .windows           import Window
+from .windows           import Monitor, monitors
+from .windows           import Clipboard
+
 
 #---------------------------------------------------------------------------
 from .language          import (Integer, IntegerRef,

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -48,9 +48,13 @@ from .grammar.recobs    import (RecognitionObserver, RecognitionHistory,
 #---------------------------------------------------------------------------
 
 from .actions           import (ActionBase, DynStrActionBase, ActionError,
-                                 Repeat, Key, Text, Mouse, Paste, Pause,
-                                 Mimic, Playback, WaitWindow, FocusWindow,
-                                 Function, StartApp, BringApp, PlaySound)
+                                Repeat, Key, Text, Mouse, Paste, Pause,
+                                Mimic, Playback, WaitWindow, FocusWindow,
+                                Function, StartApp, BringApp, PlaySound,
+                                Typeable, Keyboard, typeables,
+                                KeyboardInput, MouseInput, HardwareInput,
+                                make_input_array, send_input_array
+                                )
 
 #---------------------------------------------------------------------------
 

--- a/dragonfly/actions/__init__.py
+++ b/dragonfly/actions/__init__.py
@@ -18,17 +18,39 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
+import sys
+
+# Import OS-agnostic classes
+from .action_pause        import Pause
+from .action_function     import Function
+from .action_playback     import Playback
 from .action_base         import (ActionBase, DynStrActionBase,
                                   Repeat, ActionError)
-# from .action_key          import Key
-# from .action_text         import Text
-# from .action_mouse        import Mouse
-# from .action_paste        import Paste
-from .action_pause        import Pause
 from .action_mimic        import Mimic
-# from .action_playback     import Playback
-from .action_function     import Function
-# from .action_waitwindow   import WaitWindow
-# from .action_focuswindow  import FocusWindow
-# from .action_startapp     import StartApp, BringApp
-# from .action_playsound    import PlaySound
+
+# Import Windows OS dependent classes only for Windows
+if sys.platform.startswith("win"):
+    from .action_key          import Key
+    from .action_text         import Text
+    from .action_mouse        import Mouse
+    from .action_paste        import Paste
+    from .action_waitwindow   import WaitWindow
+    from .action_focuswindow  import FocusWindow
+    from .action_startapp     import StartApp, BringApp
+    from .action_playsound    import PlaySound
+    from .keyboard import Typeable, Keyboard
+    from .typeables import typeables
+    from .sendinput import (KeyboardInput, MouseInput, HardwareInput,
+                            make_input_array, send_input_array)
+else:
+    from ..os_dependent_mock import Key
+    from ..os_dependent_mock import Text
+    from ..os_dependent_mock import Mouse
+    from ..os_dependent_mock import Paste
+    from ..os_dependent_mock import WaitWindow
+    from ..os_dependent_mock import FocusWindow
+    from ..os_dependent_mock import StartApp, BringApp
+    from ..os_dependent_mock import PlaySound
+    from ..os_dependent_mock import (Typeable, Keyboard, typeables, KeyboardInput,
+                                     MouseInput, HardwareInput, make_input_array,
+                                     send_input_array)

--- a/dragonfly/actions/actions.py
+++ b/dragonfly/actions/actions.py
@@ -23,18 +23,32 @@ This file offers access to various action classes.
 
 """
 
+import sys
 
+# Import OS-agnostic classes
+from .action_pause        import Pause
+from .action_function     import Function
+from .action_playback     import Playback
 from .action_base         import (ActionBase, DynStrActionBase,
                                   Repeat, ActionError)
-# from .action_key          import Key
-# from .action_text         import Text
-# from .action_mouse        import Mouse
-# from .action_paste        import Paste
-# from .action_pause        import Pause
-# from .action_mimic        import Mimic
-# from .action_playback     import Playback
-# from .action_function     import Function
-# from .action_waitwindow   import WaitWindow
-# from .action_focuswindow  import FocusWindow
-# from .action_startapp     import StartApp, BringApp
-# from .action_playsound    import PlaySound
+from .action_mimic        import Mimic
+
+# Import Windows OS dependent classes only for Windows
+if sys.platform.startswith("win"):
+    from .action_key          import Key
+    from .action_text         import Text
+    from .action_mouse        import Mouse
+    from .action_paste        import Paste
+    from .action_waitwindow   import WaitWindow
+    from .action_focuswindow  import FocusWindow
+    from .action_startapp     import StartApp, BringApp
+    from .action_playsound    import PlaySound
+else:
+    from ..os_dependent_mock import Key
+    from ..os_dependent_mock import Text
+    from ..os_dependent_mock import Mouse
+    from ..os_dependent_mock import Paste
+    from ..os_dependent_mock import WaitWindow
+    from ..os_dependent_mock import FocusWindow
+    from ..os_dependent_mock import StartApp, BringApp
+    from ..os_dependent_mock import PlaySound

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -82,6 +82,24 @@ def get_engine(name=None):
             if name:
                 raise EngineError(message)
 
+    if not name or name == "google":
+        # Attempt to retrieve the Google Cloud API back-end.
+        try:
+            from .backend_google import is_engine_available
+            from .backend_google import get_engine as get_specific_engine
+            if is_engine_available():
+                _default_engine = get_specific_engine()
+                _engines_by_name["google"] = _default_engine
+                return _default_engine
+        except Exception as e:
+            message = ("Exception while initializing google engine:"
+                       " %s" % (e,))
+            log.exception(message)
+            traceback.print_exc()
+            print message
+            if name:
+                raise EngineError(message)
+
     if not name:
         raise EngineError("No usable engines found.")
     else:

--- a/dragonfly/engines/backend_google/__init__.py
+++ b/dragonfly/engines/backend_google/__init__.py
@@ -27,3 +27,37 @@ SR back-end package for Google Cloud Speech API.
 import logging
 _log = logging.getLogger("engine.google")
 
+#---------------------------------------------------------------------------
+
+# Module level singleton instance of this engine implementation.
+_engine = None
+
+
+def is_engine_available():
+    """ Check whether Google engine is available. """
+    global _engine
+    if _engine:
+        return True
+
+    # Attempt to import dependencies.
+    try:
+        import google.cloud.speech
+        import inflect
+        import pyaudio
+    except ImportError as e:
+        _log.info("Failed to import dependency package: %s" % (e,))
+        return False
+    except Exception as e:
+        _log.exception("Exception during import of engine dependencies: %s" % (e,))
+        return False
+
+    return True
+
+
+def get_engine():
+    """ Retrieve the Google back-end engine object. """
+    global _engine
+    if not _engine:
+        from .engine import GoogleSpeechEngine
+        _engine = GoogleSpeechEngine()
+    return _engine

--- a/dragonfly/engines/backend_google/engine.py
+++ b/dragonfly/engines/backend_google/engine.py
@@ -103,6 +103,7 @@ class GoogleSpeechEngine(EngineBase):
 
     def __init__(self):
         super(GoogleSpeechEngine, self).__init__()
+        self._connected = False
         self._timer_manager = SimpleTimerManager(0.02, self)
         self._inflect = inflect.engine()
         self._toaster = win10toast.ToastNotifier() if "win10toast" in sys.modules else None
@@ -121,7 +122,10 @@ class GoogleSpeechEngine(EngineBase):
         return "en"
 
     def connect(self):
-        pass
+        self._connected = True
+
+    def disconnect(self):
+        self._connected = False
 
     def _load_grammar(self, grammar):
         grammar.engine = self
@@ -288,8 +292,9 @@ class GoogleSpeechEngine(EngineBase):
             single_utterance=True,
         )
 
+        self.connect()
         with MicrophoneStream(RATE, CHUNK) as stream:
-            while True:
+            while self._connected:
                 shutdown_event = threading.Event()
                 audio_generator = stream.generator(shutdown_event)
                 requests = (types.StreamingRecognizeRequest(audio_content=content)

--- a/dragonfly/engines/backend_google/engine.py
+++ b/dragonfly/engines/backend_google/engine.py
@@ -98,6 +98,7 @@ class MicrophoneStream(object):
 
 class GoogleSpeechEngine(EngineBase):
 
+    _name = "google"
     DictationContainer = GoogleSpeechDictationContainer
 
     def __init__(self):

--- a/dragonfly/grammar/grammar.py
+++ b/dragonfly/grammar/grammar.py
@@ -30,4 +30,4 @@
 # Grammar classes.
 
 from .grammar_base        import Grammar
-# from .grammar_connection  import ConnectionGrammar
+from .grammar_connection  import ConnectionGrammar

--- a/dragonfly/grammar/grammar_connection.py
+++ b/dragonfly/grammar/grammar_connection.py
@@ -22,9 +22,23 @@
     This file implements the ConnectionGrammar class.
 """
 
+try:
+    from win32com.client import Dispatch
+    from pywintypes import com_error
+except ImportError, error:
+    import sys
+    if sys.platform.startswith("win"):
+        raise error
 
-from win32com.client import Dispatch
-from pywintypes import com_error
+    # These modules aren't available on non-Windows platforms, so mock what is used.
+    class COMError(Exception):
+        pass
+
+    com_error = COMError
+
+    class Dispatch(object):
+        def __init__(self, _):
+            pass
 
 from dragonfly.grammar.grammar_base import Grammar
 

--- a/dragonfly/os_dependent_mock.py
+++ b/dragonfly/os_dependent_mock.py
@@ -1,0 +1,102 @@
+# This file is part of Aenea
+#
+# Aenea is free software: you can redistribute it and/or modify it under
+# the terms of version 3 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# Aenea is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Aenea.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (2014) Alex Roper
+# Alex Roper <alex@aroper.net>
+
+"""
+Mock module to allow dragonfly to be imported on linux locally.
+Heavily modified to allow more dragonfly functionality to work
+regardless of operating system.
+"""
+from .actions import ActionBase, DynStrActionBase
+
+
+# Mock ActionBase and DynStrActionBase classes
+
+def mock_action(*args, **kwargs):
+    return ActionBase()
+
+
+def mock_dyn_str_action(*args, **kwargs):
+    return DynStrActionBase(*args, **kwargs)
+
+Text = mock_dyn_str_action
+Key = mock_dyn_str_action
+Mouse = mock_dyn_str_action
+Paste = mock_dyn_str_action
+WaitWindow = mock_action
+FocusWindow = mock_action
+StartApp = mock_action
+BringApp = mock_action
+PlaySound = mock_action
+
+
+class _WindowInfo(object):
+    # TODO Use proxy contexts instead
+    executable = ""
+    title = ""
+    handle = ""
+
+
+class Window(object):
+    @staticmethod
+    def get_foreground():
+        return _WindowInfo
+
+
+class MockBase(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class Clipboard(MockBase):
+    pass
+
+
+class HardwareInput(MockBase):
+    pass
+
+
+class Keyboard(MockBase):
+    pass
+
+
+class KeyboardInput(MockBase):
+    pass
+
+
+monitors = []
+
+
+class Monitor(MockBase):
+    pass
+
+
+class MouseInput(MockBase):
+    pass
+
+
+class Typeable(object):
+    pass
+
+typeables = {}
+
+
+def make_input_array(inputs):
+    return inputs
+
+
+def send_input_array(input_array):
+    pass

--- a/dragonfly/windows/__init__.py
+++ b/dragonfly/windows/__init__.py
@@ -17,3 +17,20 @@
 #   License along with Dragonfly.  If not, see 
 #   <http://www.gnu.org/licenses/>.
 #
+
+
+import sys
+
+# OS agnostic imports
+from rectangle import Rectangle, unit
+from point     import Point
+
+# Windows-specific
+if sys.platform.startswith("win"):
+    from window    import Window
+    from monitor   import Monitor, monitors
+    from clipboard import Clipboard
+else:  # Mock imports
+    from ..os_dependent_mock      import Window
+    from ..os_dependent_mock      import Monitor, monitors
+    from ..os_dependent_mock      import Clipboard

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,11 @@ setup(
 
       install_requires=[
                         "setuptools >= 0.6c7",
-                        # "pywin32",
+                        "pywin32;platform_system=='Windows'",
+                        "win10toast;platform_system=='Windows'",
+                        "pyaudio",
+                        "google-cloud-speech",
+                        "inflect"
                        ],
 
       classifiers=[


### PR DESCRIPTION
Hello there. I've made a few improvements to keep things more cross-platform, added a section on the Google engine to the readme, plus two minor additions to the engine.

The Windows-only dragonfly action classes are mocked to yield `ActionBase` or `DynStrActionBase` objects here, as they are in my fork. One effect of this is that *Aenea* will use them for local actions with no problem, which simplifies things a bit. The `natlinkmain` import in *client/aenea/config.py* needs to be moved into its own try catch block for this to work.